### PR TITLE
Linkfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ the package maintainers declare that all the software in this package is release
     PackageLicenseDeclared: MIT
 
 There are many more tags you can use.  They are explained in the full
-[SPDX specification](https://spdx.org/SPDX-specifications/spdx-version-2.0).
+[SPDX specification](https://spdx.org/spdx-specification-21-web-version#h.4d34og8).
 
 Now, a personal note.
 Many of the tags and features in the SPDX file specification


### PR DESCRIPTION
The old link was a 404. I fixed it using a deep link to the most fitting section.